### PR TITLE
batched copy with offset

### DIFF
--- a/src/Platforms/OMPTarget/ompBLAS.hpp
+++ b/src/Platforms/OMPTarget/ompBLAS.hpp
@@ -261,6 +261,46 @@ ompBLAS_status copy_batched(ompBLAS_handle& handle,
                             const int incy,
                             const int batch_count);
 
+ompBLAS_status copy_batched_offset(ompBLAS_handle& handle,
+                                   const int n,
+                                   const float* const x[],
+                                   const int x_offset,
+                                   const int incx,
+                                   float* const y[],
+                                   const int y_offset,
+                                   const int incy,
+                                   const int batch_count);
+
+ompBLAS_status copy_batched_offset(ompBLAS_handle& handle,
+                                   const int n,
+                                   const double* const x[],
+                                   const int x_offset,
+                                   const int incx,
+                                   double* const y[],
+                                   const int y_offset,
+                                   const int incy,
+                                   const int batch_count);
+
+ompBLAS_status copy_batched_offset(ompBLAS_handle& handle,
+                                   const int n,
+                                   const std::complex<float>* const x[],
+                                   const int x_offset,
+                                   const int incx,
+                                   std::complex<float>* const y[],
+                                   const int y_offset,
+                                   const int incy,
+                                   const int batch_count);
+
+ompBLAS_status copy_batched_offset(ompBLAS_handle& handle,
+                                   const int n,
+                                   const std::complex<double>* const x[],
+                                   const int x_offset,
+                                   const int incx,
+                                   std::complex<double>* const y[],
+                                   const int y_offset,
+                                   const int incy,
+                                   const int batch_count);
+
 } // namespace ompBLAS
 
 } // namespace qmcplusplus


### PR DESCRIPTION
changed `copy_batched` to allow incx and incy greater than 1

added a `copy_batched_offset` for easier interface

If you already have a list of pointers to the start of each array in the batch, this allows you to specify an offset that will be used for all of them instead of creating a new list of device pointers which have been shifted by the offset (we wouldn't need this if everything was uniformly sized and contiguous; we could just make a `copy_batch_strided` where we pass a single pointer each for x and y which already account for the offset)