### PR TITLE
SoaAtomicBasisSet mw_evaluateV_mvp

### DIFF
--- a/src/Numerics/SoaCartesianTensor.h
+++ b/src/Numerics/SoaCartesianTensor.h
@@ -39,6 +39,7 @@ struct SoaCartesianTensor
 {
   using value_type = T;
   using ggg_type   = TinyVector<Tensor<T, 3>, 3>;
+  using xyz_type   = TinyVector<T, 3>;
 
   ///maximum angular momentum
   size_t Lmax;
@@ -76,6 +77,16 @@ struct SoaCartesianTensor
 
   ///compute Ylm
   inline void evaluateV(T x, T y, T z) { evaluateV(x, y, z, cXYZ.data(0)); }
+
+  inline void mw_evaluateV(xyz_type* xyz, T* XYZ, size_t nr, size_t nlm) const
+  {
+    for (size_t ir = 0; ir < nr; ir++)
+      evaluate_bare(xyz[ir][0], xyz[ir][1], xyz[ir][2], XYZ + (ir * nlm));
+    for (size_t ir = 0; ir < nr; ir++)
+      for (int i = 0, nl = cXYZ.size(); i < nl; i++)
+        XYZ[ir * nlm + i] *= NormFactor[i];
+  }
+
 
   ///makes a table of \f$ r^l S_l^m \f$ and their gradients up to Lmax.
   void evaluateVGL(T x, T y, T z);

--- a/src/Numerics/SoaSphericalTensor.h
+++ b/src/Numerics/SoaSphericalTensor.h
@@ -49,6 +49,7 @@ struct SoaSphericalTensor
   aligned_vector<T> Factor2L;
   ///composite
   VectorSoaContainer<T, 5> cYlm;
+  using xyz_type = TinyVector<T, 3>;
 
   explicit SoaSphericalTensor(const int l_max, bool addsign = false);
 
@@ -63,6 +64,16 @@ struct SoaSphericalTensor
     evaluate_bare(x, y, z, Ylm);
     for (int i = 0, nl = cYlm.size(); i < nl; i++)
       Ylm[i] *= NormFactor[i];
+  }
+
+  ///compute Ylm
+  inline void mw_evaluateV(xyz_type* xyz, T* Ylm, size_t nr, size_t nlm) const
+  {
+    for (size_t ir = 0; ir < nr; ir++)
+      evaluate_bare(xyz[ir][0], xyz[ir][1], xyz[ir][2], Ylm + (ir * nlm));
+    for (size_t ir = 0; ir < nr; ir++)
+      for (int i = 0, nl = cYlm.size(); i < nl; i++)
+        Ylm[ir * nlm + i] *= NormFactor[i];
   }
 
   ///compute Ylm

--- a/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
+++ b/src/QMCWaveFunctions/LCAO/MultiFunctorAdapter.h
@@ -57,6 +57,27 @@ struct MultiFunctorAdapter
       u[i] = Rnl[i]->f(r);
   }
 
+  inline void mw_evaluate(RealType* restrict r_list,
+                          RealType* restrict u,
+                          size_t nr,
+                          size_t maxnumsplines,
+                          RealType Rmax)
+  {
+    for (size_t ir = 0; ir < nr; ir++)
+    {
+      if (r_list[ir] >= Rmax)
+      {
+        for (size_t i = 0, n = Rnl.size(); i < n; ++i)
+          u[ir * maxnumsplines + i] = 0.0;
+      }
+      else
+      {
+        for (size_t i = 0, n = Rnl.size(); i < n; ++i)
+          u[ir * maxnumsplines + i] = Rnl[i]->f(r_list[ir]);
+      }
+    }
+  }
+
   inline void evaluate(RealType r, RealType* restrict u, RealType* restrict du, RealType* restrict d2u)
   {
     const RealType rinv = RealType(1) / r;


### PR DESCRIPTION
mw_evaluateV_mvp for SoaAtomicBasisSet
mw_evaluateV for Ylm(cart, sph), Rnl (MultiQuintic, MultifunctorAdapter)

This is just an initial implementation, still need to consider a few things:
Data layout of several flattened arrays could change (image translation vectors, displ, dist), also might be better to just pre-compute image translation vectors once (like we already do for phase factors)
There are several places where it might be better to transpose/batch things differently across species, centers, images, basis functions