### PR TITLE
working on sparse lcao coefs

### DIFF
--- a/src/Containers/OhmmsSoA/VectorSoaContainer.h
+++ b/src/Containers/OhmmsSoA/VectorSoaContainer.h
@@ -345,6 +345,17 @@ private:
   friend struct VectorSoaContainer;
 };
 
+template<class T, unsigned D, typename Alloc>
+std::ostream& operator<<(std::ostream& out, const VectorSoaContainer<T, D, Alloc>& rhs)
+{
+  using size_type = typename VectorSoaContainer<T, D, Alloc>::size_type;
+  for (size_type i = 0; i < rhs.size(); i++)
+  {
+    out << rhs[i] << "\n";
+  }
+  return out;
+}
+
 } // namespace qmcplusplus
 
 #endif

--- a/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
+++ b/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp
@@ -74,7 +74,10 @@ LCAOrbitalSet::LCAOrbitalSet(const std::string& my_name,
     Tempv.resize(OrbitalSetSize);
     Temphv.resize(OrbitalSetSize);
     Tempghv.resize(OrbitalSetSize);
-    C = std::make_shared<OffloadValueMatrix>(OrbitalSetSize, BasisSetSize);
+    C                = std::make_shared<OffloadValueMatrix>(OrbitalSetSize, BasisSetSize);
+    use_sparse_coefs = true;
+    if (use_sparse_coefs)
+      C_csr = from_dense(C->data(), OrbitalSetSize, BasisSetSize);
   }
   LCAOrbitalSet::checkObject();
 }
@@ -83,6 +86,8 @@ LCAOrbitalSet::LCAOrbitalSet(const LCAOrbitalSet& in)
     : SPOSet(in),
       myBasisSet(in.myBasisSet->makeClone()),
       C(in.C),
+      C_csr(in.C_csr),
+      use_sparse_coefs(in.use_sparse_coefs),
       BasisSetSize(in.BasisSetSize),
       C_copy(in.C_copy),
       Identity(in.Identity),
@@ -131,7 +136,11 @@ void LCAOrbitalSet::checkObject() const
 void LCAOrbitalSet::finalizeConstruction()
 {
   if (C)
+  {
     C->updateTo();
+    if (use_sparse_coefs)
+      C_csr = from_dense(C->data(), OrbitalSetSize, BasisSetSize);
+  }
 }
 
 void LCAOrbitalSet::createResource(ResourceCollection& collection) const
@@ -180,11 +189,25 @@ void LCAOrbitalSet::evaluateValue(const ParticleSet& P, int iat, ValueVector& ps
   }
   else
   {
+    /// TODO: do sparse here
     Vector<ValueType> vTemp(Temp.data(0), BasisSetSize);
     myBasisSet->evaluateV(P, iat, vTemp.data());
     assert(psi.size() <= OrbitalSetSize);
-    ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
-    MatrixOperators::product(C_partial_view, vTemp, psi);
+    if (use_sparse_coefs)
+    {
+      app_log() << "DEBUG: sparse_d_mv evaluateValue start" << std::endl;
+      auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(psi.size());
+
+      mkl_sparse_d_mv(SPARSE_OPERATION_TRANSPOSE, 1.0, C_csr_partial.get(), C_csr_partial.descr(), vTemp.data(), 0.0,
+                      psi.data());
+      // mkl_sparse_d_mv(SPARSE_OPERATION_TRANSPOSE, 1.0, C_csr.get(), C_csr.descr(), vTemp.data(), 0.0, psi.data());
+      app_log() << "DEBUG: sparse_d_mv evaluateValue end" << std::endl;
+    }
+    else
+    {
+      ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
+      MatrixOperators::product(C_partial_view, vTemp, psi);
+    }
   }
 }
 
@@ -199,6 +222,22 @@ inline void Product_ABt(const VectorSoaContainer<T, D>& A, const Matrix<T, Alloc
   BLAS::gemm(transa, transb, B.rows(), D, B.cols(), zone, B.data(), B.cols(), A.data(), A.capacity(), zero, C.data(),
              C.capacity());
 }
+
+template<typename T, unsigned D>
+inline void Product_ABt_sparse(const VectorSoaContainer<T, D>& A,
+                               const MklSparseHandle& Bcsr,
+                               VectorSoaContainer<T, D>& C)
+{
+  constexpr char transa = 't';
+  constexpr char transb = 'n';
+  constexpr T zone(1);
+  constexpr T zero(0);
+  app_log() << "DEBUG: product_ABt_sparse start" << std::endl;
+  mkl_sparse_d_mm(SPARSE_OPERATION_TRANSPOSE, zone, Bcsr.get(), Bcsr.descr(), SPARSE_LAYOUT_ROW_MAJOR, A.data(), D,
+                  A.capacity(), zero, C.data(), C.capacity());
+  app_log() << "DEBUG: product_ABt_sparse end" << std::endl;
+}
+
 
 inline void LCAOrbitalSet::evaluate_vgl_impl(const vgl_type& temp,
                                              ValueVector& psi,
@@ -432,8 +471,18 @@ void LCAOrbitalSet::evaluateVGL(const ParticleSet& P, int iat, ValueVector& psi,
     assert(psi.size() <= OrbitalSetSize);
     {
       ScopedTimer local(mo_timer_);
-      ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
-      Product_ABt(Temp, C_partial_view, Tempv);
+      if (use_sparse_coefs)
+      {
+        app_log() << "DEBUG: abt evaluateVGL start" << std::endl;
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(psi.size());
+        Product_ABt_sparse(Temp, C_csr_partial, Tempv);
+        // Product_ABt_sparse(Temp, C_csr, Tempv);
+      }
+      else
+      {
+        ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
+        Product_ABt(Temp, C_partial_view, Tempv);
+      }
     }
     evaluate_vgl_impl(Tempv, psi, dpsi, d2psi);
   }
@@ -528,15 +577,30 @@ void LCAOrbitalSet::mw_evaluateVGLImplGEMM(const RefVectorWithLeader<SPOSet>& sp
       }
       else
       {
-        ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
-        // TODO: make class for general blas interface in Platforms
-        // have instance of that class as member of LCAOrbitalSet, call gemm through that
-        BLAS::gemm('T', 'N',
-                   requested_orb_size,        // MOs
-                   spo_list.size() * DIM_VGL, // walkers * DIM_VGL
-                   BasisSetSize,              // AOs
-                   1, C_partial_view.data(), BasisSetSize, basis_vgl_mw.data(), BasisSetSize, 0, phi_vgl_v.data(),
-                   requested_orb_size);
+        if (use_sparse_coefs)
+        {
+          app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateVGLImplGEMM start" << std::endl;
+          auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(requested_orb_size);
+          mkl_sparse_d_mm(SPARSE_OPERATION_TRANSPOSE, 1, C_csr_partial.get(), C_csr_partial.descr(),
+                          SPARSE_LAYOUT_ROW_MAJOR, basis_vgl_mw.data(),
+                          BasisSetSize,              // AOs
+                          spo_list.size() * DIM_VGL, // walkers * DIM_VGL
+                          0, phi_vgl_v.data(),
+                          requested_orb_size); // MOs
+          app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateVGLImplGEMM end" << std::endl;
+        }
+        else
+        {
+          ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
+          // TODO: make class for general blas interface in Platforms
+          // have instance of that class as member of LCAOrbitalSet, call gemm through that
+          BLAS::gemm('T', 'N',
+                     requested_orb_size,        // MOs
+                     spo_list.size() * DIM_VGL, // walkers * DIM_VGL
+                     BasisSetSize,              // AOs
+                     1, C_partial_view.data(), BasisSetSize, basis_vgl_mw.data(), BasisSetSize, 0, phi_vgl_v.data(),
+                     requested_orb_size);
+        }
       }
     }
   }
@@ -591,13 +655,28 @@ void LCAOrbitalSet::mw_evaluateValueVPsImplGEMM(const RefVectorWithLeader<SPOSet
     }
     else
     {
-      ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
-      BLAS::gemm('T', 'N',
-                 requested_orb_size, // MOs
-                 nVPs,               // walkers * Virtual Particles
-                 BasisSetSize,       // AOs
-                 1, C_partial_view.data(), BasisSetSize, vp_basis_v_mw.data(), BasisSetSize, 0, vp_phi_v.data(),
-                 requested_orb_size);
+      if (use_sparse_coefs)
+      {
+        app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateValueVPsImplGEMM start" << std::endl;
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(requested_orb_size);
+        mkl_sparse_d_mm(SPARSE_OPERATION_TRANSPOSE, 1, C_csr_partial.get(), C_csr_partial.descr(),
+                        SPARSE_LAYOUT_ROW_MAJOR, vp_basis_v_mw.data(),
+                        BasisSetSize, // AOs
+                        nVPs,         // walkers * Virtual Particles
+                        0, vp_phi_v.data(),
+                        requested_orb_size); // MOs
+        app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateValueVPsImplGEMM end" << std::endl;
+      }
+      else
+      {
+        ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
+        BLAS::gemm('T', 'N',
+                   requested_orb_size, // MOs
+                   nVPs,               // walkers * Virtual Particles
+                   BasisSetSize,       // AOs
+                   1, C_partial_view.data(), BasisSetSize, vp_basis_v_mw.data(), BasisSetSize, 0, vp_phi_v.data(),
+                   requested_orb_size);
+      }
     }
   }
 }
@@ -674,13 +753,28 @@ void LCAOrbitalSet::mw_evaluateValueImplGEMM(const RefVectorWithLeader<SPOSet>& 
     }
     else
     {
-      ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
-      BLAS::gemm('T', 'N',
-                 requested_orb_size, // MOs
-                 spo_list.size(),    // walkers
-                 BasisSetSize,       // AOs
-                 1, C_partial_view.data(), BasisSetSize, basis_v_mw.data(), BasisSetSize, 0, phi_v.data(),
-                 requested_orb_size);
+      if (use_sparse_coefs)
+      {
+        app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateValueImplGEMM start" << std::endl;
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(requested_orb_size);
+        mkl_sparse_d_mm(SPARSE_OPERATION_TRANSPOSE, 1, C_csr_partial.get(), C_csr_partial.descr(),
+                        SPARSE_LAYOUT_ROW_MAJOR, basis_v_mw.data(),
+                        BasisSetSize,    // AOs
+                        spo_list.size(), // walkers
+                        0, phi_v.data(),
+                        requested_orb_size); // MOs
+        app_log() << "DEBUG: mkl_sparse_d_mm in mw_evaluateValueImplGEMM end" << std::endl;
+      }
+      else
+      {
+        ValueMatrix C_partial_view(C->data(), requested_orb_size, BasisSetSize);
+        BLAS::gemm('T', 'N',
+                   requested_orb_size, // MOs
+                   spo_list.size(),    // walkers
+                   BasisSetSize,       // AOs
+                   1, C_partial_view.data(), BasisSetSize, basis_v_mw.data(), BasisSetSize, 0, phi_v.data(),
+                   requested_orb_size);
+      }
     }
   }
 }
@@ -762,6 +856,7 @@ void LCAOrbitalSet::evaluateDetRatios(const VirtualParticleSet& VP,
     // when only a subset of orbitals is used, extract limited rows of C.
     Matrix<ValueType> C_occupied(C->data(), psiinv.size(), BasisSetSize);
     MatrixOperators::product_Atx(C_occupied, psiinv, invTemp);
+    /// TODO: sparse gemv here
   }
 
   for (size_t j = 0; j < VP.getTotalNum(); j++)
@@ -869,8 +964,17 @@ void LCAOrbitalSet::evaluateVGH(const ParticleSet& P, int iat, ValueVector& psi,
   else
   {
     assert(psi.size() <= OrbitalSetSize);
-    ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
-    Product_ABt(Temph, C_partial_view, Temphv);
+    if (use_sparse_coefs)
+    {
+      app_log() << "DEBUG: abt evaluateVGH start" << std::endl;
+      auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(psi.size());
+      Product_ABt_sparse(Temph, C_csr_partial, Temphv);
+    }
+    else
+    {
+      ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
+      Product_ABt(Temph, C_partial_view, Temphv);
+    }
     evaluate_vgh_impl(Temphv, psi, dpsi, dhpsi);
   }
 }
@@ -891,8 +995,17 @@ void LCAOrbitalSet::evaluateVGHGH(const ParticleSet& P,
   else
   {
     assert(psi.size() <= OrbitalSetSize);
-    ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
-    Product_ABt(Tempgh, C_partial_view, Tempghv);
+    if (use_sparse_coefs)
+    {
+      app_log() << "DEBUG: abt evaluateVGHGH start" << std::endl;
+      auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(psi.size());
+      Product_ABt_sparse(Tempgh, C_csr_partial, Tempghv);
+    }
+    else
+    {
+      ValueMatrix C_partial_view(C->data(), psi.size(), BasisSetSize);
+      Product_ABt(Tempgh, C_partial_view, Tempghv);
+    }
     evaluate_vghgh_impl(Tempghv, psi, dpsi, dhpsi, dghpsi);
   }
 }
@@ -1037,11 +1150,34 @@ void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P,
   {
     assert(logdet.cols() <= OrbitalSetSize);
     ValueMatrix C_partial_view(C->data(), logdet.cols(), BasisSetSize);
+
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
+      /// TODO: sparse
       myBasisSet->evaluateVGL(P, iat, Temp);
-      Product_ABt(Temp, C_partial_view, Tempv);
+      if (use_sparse_coefs)
+      {
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(logdet.cols());
+        app_log() << "DEBUG: abt evaluate_notranspose1 start" << std::endl;
+        Product_ABt_sparse(Temp, C_csr_partial, Tempv);
+        app_log() << "DEBUG: TEMP" << std::endl;
+        app_log() << Temp << std::endl;
+        app_log() << "DEBUG: TEMPV" << std::endl;
+        app_log() << Tempv << std::endl;
+      }
+      else
+      {
+        Product_ABt(Temp, C_partial_view, Tempv);
+        app_log() << "DEBUG: TEMP" << std::endl;
+        app_log() << Temp << std::endl;
+        app_log() << "DEBUG: TEMPV" << std::endl;
+        app_log() << Tempv << std::endl;
+      }
+      app_log() << "DEBUG: evaluate_vgl_impl evaluate_notranspose1 start" << std::endl;
+      std::cout << "DEBUG: evaluate_vgl_impl evaluate_notranspose1 start" << std::endl;
       evaluate_vgl_impl(Tempv, i, logdet, dlogdet, d2logdet);
+      app_log() << "DEBUG: evaluate_vgl_impl evaluate_notranspose1 end" << std::endl;
+      std::cout << "DEBUG: evaluate_vgl_impl evaluate_notranspose1 end" << std::endl;
     }
   }
 }
@@ -1068,7 +1204,14 @@ void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P,
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
       myBasisSet->evaluateVGH(P, iat, Temph);
-      Product_ABt(Temph, C_partial_view, Temphv);
+      if (use_sparse_coefs)
+      {
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(logdet.cols());
+        app_log() << "DEBUG: abt evaluate_notranspose2 start" << std::endl;
+        Product_ABt_sparse(Temph, C_csr_partial, Temphv);
+      }
+      else
+        Product_ABt(Temph, C_partial_view, Temphv);
       evaluate_vgh_impl(Temphv, i, logdet, dlogdet, grad_grad_logdet);
     }
   }
@@ -1097,7 +1240,14 @@ void LCAOrbitalSet::evaluate_notranspose(const ParticleSet& P,
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
       myBasisSet->evaluateVGHGH(P, iat, Tempgh);
-      Product_ABt(Tempgh, C_partial_view, Tempghv);
+      if (use_sparse_coefs)
+      {
+        auto C_csr_partial = C_csr.view_first_n_rows<double, MKL_INT>(logdet.cols());
+        app_log() << "DEBUG: abt evaluate_notranspose3 start" << std::endl;
+        Product_ABt_sparse(Tempgh, C_csr_partial, Tempghv);
+      }
+      else
+        Product_ABt(Tempgh, C_partial_view, Tempghv);
       evaluate_vghgh_impl(Tempghv, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
     }
   }
@@ -1123,7 +1273,13 @@ void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P,
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
       myBasisSet->evaluateGradSourceV(P, iat, source, iat_src, Temp);
-      Product_ABt(Temp, *C, Tempv);
+      if (use_sparse_coefs)
+      {
+        app_log() << "DEBUG: abt evaluateGradSource1 start" << std::endl;
+        Product_ABt_sparse(Temp, C_csr, Tempv);
+      }
+      else
+        Product_ABt(Temp, *C, Tempv);
       evaluate_ionderiv_v_impl(Tempv, i, gradphi);
     }
   }
@@ -1151,7 +1307,13 @@ void LCAOrbitalSet::evaluateGradSource(const ParticleSet& P,
     for (size_t i = 0, iat = first; iat < last; i++, iat++)
     {
       myBasisSet->evaluateGradSourceVGL(P, iat, source, iat_src, Tempgh);
-      Product_ABt(Tempgh, *C, Tempghv);
+      if (use_sparse_coefs)
+      {
+        app_log() << "DEBUG: abt evaluateGradSource2 start" << std::endl;
+        Product_ABt_sparse(Tempgh, C_csr, Tempghv);
+      }
+      else
+        Product_ABt(Tempgh, *C, Tempghv);
       evaluate_ionderiv_vgl_impl(Tempghv, i, grad_phi, grad_grad_phi, grad_lapl_phi);
       //  evaluate_vghgh_impl(Tempghv, i, logdet, dlogdet, grad_grad_logdet, grad_grad_grad_logdet);
     }
@@ -1172,7 +1334,13 @@ void LCAOrbitalSet::evaluateGradSourceRow(const ParticleSet& P,
   else
   {
     myBasisSet->evaluateGradSourceV(P, iel, source, iat_src, Temp);
-    Product_ABt(Temp, *C, Tempv);
+    if (use_sparse_coefs)
+    {
+      app_log() << "DEBUG: abt evaluateGradSourceRow start" << std::endl;
+      Product_ABt_sparse(Temp, C_csr, Tempv);
+    }
+    else
+      Product_ABt(Temp, *C, Tempv);
     evaluate_ionderiv_v_row_impl(Tempv, gradphi);
   }
 }
@@ -1185,6 +1353,11 @@ void LCAOrbitalSet::applyRotation(const ValueMatrix& rot_mat, bool use_stored_co
   BLAS::gemm('N', 'T', BasisSetSize, OrbitalSetSize, OrbitalSetSize, RealType(1.0), C_copy->data(), BasisSetSize,
              rot_mat.data(), OrbitalSetSize, RealType(0.0), C->data(), BasisSetSize);
   C->updateTo();
+  if (use_sparse_coefs)
+  {
+    app_log() << "DEBUG: C_csr applyRotation" << std::endl;
+    C_csr = from_dense(C->data(), OrbitalSetSize, BasisSetSize);
+  }
 
   /* debugging code
   app_log() << "PRINTING MO COEFFICIENTS AFTER ROTATION " << objectName << std::endl;


### PR DESCRIPTION
## Proposed changes

store sparse (csr) lcao coefs and use sparse gemm/gemv

added [CSRMatrix](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h#L26-L43) struct to hold data representing a CSR sparse matrix
This is in LCAOrbitalSet.h for now because we don't use it anywhere else, but if we want it to stay in the code long-term it should probably go in Containers

added [MklSparseHandle](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h#L99-L164) class.
MKL has a sparse matrix type that basically just points to the data that is contained in the CSRMatrix struct (value/colIdx/rowIdx arrays, total nrows, total ncols).
That data needs to stay alive for the lifetime of the MKL `sparse_matrix_t`, so this `MklSparseHandle` contains a shared_ptr to the underlying CSRMatrix that holds the data so that it doesn't go out of scope.

added sparse coefs `MklSparseHandle C_csr` and flag `bool use_sparse_coefs` to [`LCAOrbitalSet`](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h#L191-L192)


Everything I've added uses `double` for vals and `MKL_INT` (`int`) for indices for now, but I think there are overloads for `float` and complex types for vals, as well as for `int64_t` for indices, so I made those templated even though I don't handle any other cases for now.
If this thing is going to be merged into the main branch, it should be able to handle real/complex float/double.

The [construction](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp#L81) will pick up the value type of the coefs, but I assume it will not work for floats (for floats, we should call `mkl_sparse_s_create_csr` instead of [`mkl_sparse_d_create_csr`](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h#L124-L126), and we will also need to call mkl_sparse_s_mm/mv instead of mkl_sparse_d_mm/mv.

For a slice containing the first n rows (and all columns), we can use the same underlying val/colIndex/rowIndex data without reconstructing anything, so there's [a function](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.h#L138-L152) that does that.

For the actual linear algebra, I made a [`product_ABt_sparse`](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp#L223-L234) which should be equivalent to `product_ABt` (dense), but it will need some more careful handling of types to work with anything other than doubles. In places where `product_ABt` was used, I now use `product_ABt_sparse`.

In places where `MatrixOperators::product`  or `MatrixOperators::product_Atx` was called, I just [directly call mkl_sparse_d_mv](https://github.com/kgasperich/qmcpack/blob/4e46c213c13b896d9f7109eb7e5d52619a90e051/src/QMCWaveFunctions/LCAO/LCAOrbitalSet.cpp#L197-L207) .

There were a few `gemm` calls, and in those places I now call `mkl_sparse_d_mm`.


## TODO
- [ ] move to Containers or some other more appropriate place in the code
- [ ] extend to allow real/complex float/double
- [ ] generalize to more than just mkl implementation; add wrappers
- [ ] add input options 
`bool allow_sparse` (default false);
`double sparse_threshold`
only use sparse if `(allow_sparse && ((C_csr.nnz /( C.rows() * C.cols())) < sparse_threshold))`

## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- New feature

### Does this introduce a breaking change?

- Yes

## What systems has this change been tested on?
Endymion

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
